### PR TITLE
Réduit l'espacement des sous-titres

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,11 @@
 <main>
   <div class="centered-container">
     <h1>Hôtel Grill</h1>
-    <p class="subtitle">Gérez vos réservations de buanderie.</p>
-    <p class="subtitle">Planning nettoyage cuisine.</p>
-    <p class="subtitle">Demandes et signalements.</p>
+    <div class="subtitles">
+      <p class="subtitle">Gérez vos réservations de buanderie.</p>
+      <p class="subtitle">Planning nettoyage cuisine.</p>
+      <p class="subtitle">Demandes et signalements.</p>
+    </div>
   </div>
   <div class="cards-container">
 

--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@ h1 {
 .subtitle {
   font-size: 1rem;
   text-align: center;
-  margin-bottom: 3rem;
+  margin: 0;
   opacity: 0.8;
 }
 
@@ -266,10 +266,12 @@ h1 {
   gap: 5px; /* petit espace entre les lignes */
 }
 
-.subtitle {
-  margin: 0;
-}
 
+.subtitles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
 
 .centered-container {
   height: 100vh; /* prend toute la hauteur */


### PR DESCRIPTION
## Résumé
- regroupe les phrases d’introduction dans `<div class="subtitles">`
- élimine les marges inutiles et ajoute une règle `.subtitles` pour contrôler l’écart

## Test
- `npx eslint` *(échoue: fichier ou dossier inexistant)*


------
https://chatgpt.com/codex/tasks/task_e_68557a7bc21483249a124f72434e65d0